### PR TITLE
update semver version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "gh-releases": "0.4.0",
-    "semver": "~2.2.1"
+    "semver": "4"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
There is no relevant API difference.

But depending on old semver version causes issues with deduplication, if I use `semver` library elsewhere.
